### PR TITLE
Add basic routing, navigation menu, dashboard, and Auth0 login page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,10 +16,13 @@
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
     "@mui/material": "^5.15.8",
+    "@mui/icons-material": "^5.15.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.3",
-    "redux": "^4.2.1"
+    "redux": "^4.2.1",
+    "react-router-dom": "^6.21.1",
+    "@auth0/auth0-react": "^2.1.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.39",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,11 +1,18 @@
-import React from 'react';
+import { FC } from "react";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import NavigationMenu from "./components/NavigationMenu";
+import Dashboard from "./pages/Dashboard";
+import Login from "./pages/Login";
 
-export const App: React.FC = () => {
+const App: FC = () => {
   return (
-    <div>
-      <h1>Accounting Dashboard</h1>
-      <p>Welcome to the accounting app.</p>
-    </div>
+    <BrowserRouter>
+      <NavigationMenu />
+      <Routes>
+        <Route path="/" element={<Login />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+      </Routes>
+    </BrowserRouter>
   );
 };
 

--- a/frontend/src/components/NavigationMenu.tsx
+++ b/frontend/src/components/NavigationMenu.tsx
@@ -1,0 +1,63 @@
+import { FC, useState } from "react";
+import {
+  AppBar,
+  Toolbar,
+  Typography,
+  IconButton,
+  Drawer,
+  List,
+  ListItem,
+  ListItemText,
+  Box
+} from "@mui/material";
+import MenuIcon from "@mui/icons-material/Menu";
+import { Link as RouterLink } from "react-router-dom";
+
+const NavigationMenu: FC = () => {
+  const [open, setOpen] = useState(false);
+
+  const toggleDrawer = (state: boolean) => () => setOpen(state);
+
+  return (
+    <>
+      <AppBar position="static">
+        <Toolbar>
+          <IconButton
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            onClick={toggleDrawer(true)}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" sx={{ flexGrow: 1 }}>
+            Accounting App
+          </Typography>
+        </Toolbar>
+      </AppBar>
+
+      <Drawer anchor="left" open={open} onClose={toggleDrawer(false)}>
+        <Box
+          sx={{ width: 250 }}
+          role="presentation"
+          onClick={toggleDrawer(false)}
+          onKeyDown={toggleDrawer(false)}
+        >
+          <List>
+            <ListItem button component={RouterLink} to="/dashboard">
+              <ListItemText primary="Dashboard" />
+            </ListItem>
+            <ListItem button component={RouterLink} to="/invoices">
+              <ListItemText primary="Invoices" />
+            </ListItem>
+            <ListItem button component={RouterLink} to="/reports">
+              <ListItemText primary="Reports" />
+            </ListItem>
+          </List>
+        </Box>
+      </Drawer>
+    </>
+  );
+};
+
+export default NavigationMenu;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
+import { Auth0Provider } from '@auth0/auth0-react';
 import App from './App';
 
 const container = document.getElementById('root');
 if (container) {
   const root = createRoot(container);
-  root.render(<App />);
+  root.render(
+    <Auth0Provider
+      domain={import.meta.env.VITE_AUTH0_DOMAIN}
+      clientId={import.meta.env.VITE_AUTH0_CLIENT_ID}
+      authorizationParams={{ redirect_uri: window.location.origin }}
+    >
+      <App />
+    </Auth0Provider>
+  );
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,33 @@
+import { FC } from "react";
+import { Grid, Paper, Typography } from "@mui/material";
+
+const Dashboard: FC = () => {
+  return (
+    <Grid container spacing={3} sx={{ mt: 2 }}>
+      <Grid item xs={12} md={4}>
+        <Paper sx={{ p: 2 }}>
+          <Typography variant="h6">Account Balance</Typography>
+          <Typography variant="h4">$12,345.67</Typography>
+        </Paper>
+      </Grid>
+
+      <Grid item xs={12} md={8}>
+        <Paper sx={{ p: 2 }}>
+          <Typography variant="h6" gutterBottom>
+            Recent Transactions
+          </Typography>
+          {/* Placeholder: render list/table of transactions */}
+        </Paper>
+      </Grid>
+
+      <Grid item xs={12}>
+        <Paper sx={{ p: 2 }}>
+          <Typography variant="h6">Cash Flow</Typography>
+          {/* Placeholder: chart component goes here */}
+        </Paper>
+      </Grid>
+    </Grid>
+  );
+};
+
+export default Dashboard;

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,0 +1,50 @@
+import { FC, useState } from "react";
+import { TextField, Button, Box, Typography } from "@mui/material";
+import { useAuth0 } from "@auth0/auth0-react";
+
+const Login: FC = () => {
+  const { loginWithRedirect } = useAuth0();
+  const [email, setEmail] = useState("");
+
+  const handleLogin = () =>
+    loginWithRedirect({
+      authorizationParams: { login_hint: email }
+    });
+
+  return (
+    <Box
+      sx={{
+        mt: 8,
+        mx: "auto",
+        width: 360,
+        p: 4,
+        boxShadow: 3,
+        borderRadius: 2
+      }}
+    >
+      <Typography variant="h5" sx={{ mb: 3 }} align="center">
+        Sign In
+      </Typography>
+
+      <TextField
+        label="Email"
+        type="email"
+        fullWidth
+        sx={{ mb: 2 }}
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+      />
+
+      <Button
+        variant="contained"
+        fullWidth
+        color="primary"
+        onClick={handleLogin}
+      >
+        Continue with Auth0
+      </Button>
+    </Box>
+  );
+};
+
+export default Login;


### PR DESCRIPTION
## Summary
- add react-router-based navigation with menu component
- create dashboard and login pages
- integrate Auth0 provider

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'react', '@auth0/auth0-react', etc. because dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68aeca9a2c788333b3f6b46164df2965